### PR TITLE
Fix sponsors logo positionning

### DIFF
--- a/src/includes/scss/_page.scss
+++ b/src/includes/scss/_page.scss
@@ -62,21 +62,32 @@
 }
 
 .sponsors {
-  text-align: center;
   ul {
     margin: 0;
     padding: 0;
+
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+
     list-style: none;
-  }
 
-  li {
-    max-width: 150px;
-    height: 150px;
-    display: inline-block;
-    padding: 10px;
-  }
+    li {
+      height: 150px;
+      width: 150px;
 
-  img {
-    object-fit: contain;
+      padding: 2rem;
+
+      a {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        height: 100%;
+        width: 100%;
+      }
+    }
   }
 }


### PR DESCRIPTION
Some logos where not display correctly and the view was not consistent.
Fixed with some magically powder and flexbox 🪄

# Old
![claviers-mecaniques org_meetup_](https://user-images.githubusercontent.com/19686996/184501381-ead446d9-12cd-40fb-8556-b7210be4cdab.png)

# New
![localhost_8080_meetup_](https://user-images.githubusercontent.com/19686996/184501403-57e8a958-29d0-4b2e-bf3a-2d172b6375b8.png)

